### PR TITLE
Update quickstart.mdx

### DIFF
--- a/docs/docs/get_started/quickstart.mdx
+++ b/docs/docs/get_started/quickstart.mdx
@@ -81,7 +81,6 @@ LangChain provides several objects to easily distinguish between different roles
 - `FunctionMessage`: A `ChatMessage` coming from a function call.
 
 If none of those roles sound right, there is also a `ChatMessage` class where you can specify the role manually.
-For more information on how to use these different messages most effectively, see our prompting guide.
 
 LangChain provides a standard interface for both, but it's useful to understand this difference in order to construct prompts for a given language model.
 The standard interface that LangChain provides has two methods:


### PR DESCRIPTION
**Description**
Unable to find resource titled "prompting guide." Either link to a prompting guide here or remove the reference to the resource. For a quickstart, it seems helpful to just keep the tutorial focused and linear.
